### PR TITLE
feat: Add jekyll-redirect-from and /privacy redirect (IPAY-2781)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "minima", "~> 2.0"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins
-
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
@@ -34,3 +33,4 @@ gem 'csv'
 gem 'logger'
 gem 'base64'
 gem 'bigdecimal'
+gem 'jekyll-redirect-from'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,12 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
+    ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-darwin)
     forwardable-extended (2.6.0)
+    google-protobuf (4.29.3-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.29.3-x86_64-darwin)
       bigdecimal
       rake (>= 13)
@@ -38,6 +42,8 @@ GEM
       webrick (~> 1.7)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-seo-tag (2.7.1)
@@ -68,6 +74,8 @@ GEM
     rexml (3.2.4)
     rouge (4.5.1)
     safe_yaml (1.0.5)
+    sass-embedded (1.83.4-arm64-darwin)
+      google-protobuf (~> 4.29)
     sass-embedded (1.83.4-x86_64-darwin)
       google-protobuf (~> 4.29)
     terminal-table (3.0.2)
@@ -76,6 +84,7 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-darwin-23
 
@@ -85,6 +94,7 @@ DEPENDENCIES
   csv
   jekyll (~> 4.3)
   jekyll-feed (~> 0.6)
+  jekyll-redirect-from
   logger
   minima (~> 2.0)
   rexml

--- a/_config.yml
+++ b/_config.yml
@@ -71,6 +71,7 @@ collections:
 markdown: kramdown
 plugins:
   - jekyll-feed
+  - jekyll-redirect-from
 
 
 include: [".well-known"]

--- a/gizlilik-ve-guvenlik-politikasi.md
+++ b/gizlilik-ve-guvenlik-politikasi.md
@@ -2,6 +2,8 @@
 layout: terms
 title: Valenspara Gizlilik ve Güvenlik Politikası  
 permalink: /gizlilik-ve-guvenlik-politikasi/
+redirect_from:
+  - /privacy/
 ---
 
 


### PR DESCRIPTION
Enable the jekyll-redirect-from plugin (added to Gemfile and _config.yml) and wire up a redirect for /privacy/ to the existing Turkish privacy policy by adding redirect_from to gizlilik-ve-guvenlik-politikasi.md.